### PR TITLE
Group data based on OIM resource group

### DIFF
--- a/config/osg_graphs.conf
+++ b/config/osg_graphs.conf
@@ -22,10 +22,10 @@ image=/bar_graphs/osg_wall_hours
 image=/cumulative_graphs/osg_wall_cumulative
 
 [facility_hours_bar_smry]
-image=/bar_graphs/facility_hours_bar_smry?span=604800&starttime=:today-52*7*86400&endtime=:today
+image=/bar_graphs/facility_hours_bar_smry?span=604800&starttime=:today-52*7*86400&endtime=:today&group=resource_group
 
 [facility_success_cumulative_smry]
-image=/cumulative_graphs/facility_success_cumulative_smry?span=604800&starttime=:today-52*7*86400&endtime=:today
+image=/cumulative_graphs/facility_success_cumulative_smry?span=604800&starttime=:today-52*7*86400&endtime=:today&group=resource_group
 
 [facility_transfer_rate]
 image=/transfer_graphs/facility_transfer_rate


### PR DESCRIPTION
Instead of showing each Gratia sitename (which corresponds to OIM resource), group based on resource group.
